### PR TITLE
Fix inexistent ID

### DIFF
--- a/src/api/app/crud.py
+++ b/src/api/app/crud.py
@@ -11,9 +11,14 @@ def create_spectrum(teff: float, logg: float, wstart: float, wend: float, **kwar
     return {"id": task.id}
 
 
-def get_task(task_id: UUID, page: int = 1, per_page: int = 20) -> Optional[Dict[str, Any]]:
+def get_task(
+    task_id: UUID, page: int = 1, per_page: int = 20
+) -> Optional[Dict[str, Any]]:
+
     task_result = celery_app.AsyncResult(str(task_id))
-    if task_result.status == 'PENDING':
+
+    if task_result.status == "PENDING":
+        # It is not a valid task
         return None
 
     response = dict(id=task_id, status=task_result.status)

--- a/src/api/app/crud.py
+++ b/src/api/app/crud.py
@@ -1,3 +1,4 @@
+from typing import Optional, Dict, Any
 from uuid import UUID
 from app.settings import celery_app
 
@@ -10,8 +11,11 @@ def create_spectrum(teff: float, logg: float, wstart: float, wend: float, **kwar
     return {"id": task.id}
 
 
-def get_task(task_id: UUID, page: int = 1, per_page: int = 20):
+def get_task(task_id: UUID, page: int = 1, per_page: int = 20) -> Optional[Dict[str, Any]]:
     task_result = celery_app.AsyncResult(str(task_id))
+    if task_result.status == 'PENDING':
+        return None
+
     response = dict(id=task_id, status=task_result.status)
     if task_result.ready():
         response.update(

--- a/src/api/app/schemas.py
+++ b/src/api/app/schemas.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Union
 from datetime import datetime
 from uuid import UUID
 from pydantic import BaseModel, PositiveFloat, PositiveInt
@@ -51,3 +51,7 @@ class TaskResult(TaskBase):
 
 class Health(BaseModel):
     status: bool
+
+
+class Detail(BaseModel):
+    detail: str

--- a/src/api/app/settings.py
+++ b/src/api/app/settings.py
@@ -1,5 +1,6 @@
 import os
 from celery import Celery
+from celery.signals import after_task_publish
 
 SYNSPEC_PATH = os.getenv("SYNSPEC_DIRPATH")
 
@@ -9,3 +10,12 @@ celery_app = Celery(
     broker=os.getenv("CELERY_BROKER_URL"),
 )
 celery_app.conf.task_routes = {"app.tasks.run_synspec": "synspec-queue"}
+
+
+@after_task_publish.connect
+def update_sent_state(sender=None, headers=None, **kwargs):
+    task = celery_app.tasks.get(sender)
+    backend = task.backend if task else celery_app.backend
+
+    if backend.get_state(headers["id"]) == "PENDING":  # Task does not exists in backend
+        backend.store_result(headers["id"], None, "SENT")

--- a/src/api/tests/test_crud.py
+++ b/src/api/tests/test_crud.py
@@ -54,7 +54,7 @@ def test_get_result_ready(celery_app, mocker):
 
 
 def test_get_result_not_ready(celery_app, mocker):
-    test_status = "PENDING"
+    test_status = "SENT"
 
     test_response_payload = {
         "id": _TEST_UUID,

--- a/src/api/tests/test_crud.py
+++ b/src/api/tests/test_crud.py
@@ -74,3 +74,19 @@ def test_get_result_not_ready(celery_app, mocker):
 
     result = crud.get_task(_TEST_UUID)
     assert result == test_response_payload  # nosec
+
+
+def test_get_result_inexistent_id(celery_app, mocker):
+    class AsyncResult:
+        status = "PENDING"
+
+        @staticmethod
+        def ready():
+            return False
+
+    mocker.patch(
+        "app.settings.celery_app.AsyncResult", return_value=AsyncResult,
+    )
+
+    result = crud.get_task(_TEST_UUID)
+    assert result is None  # nosec

--- a/src/api/tests/test_main.py
+++ b/src/api/tests/test_main.py
@@ -66,6 +66,19 @@ def test_synspec_get_route(client: TestClient, monkeypatch):
     assert response.json() == _TEST_TASK_RESULT  # nosec
 
 
+def test_sysnpec_get_route_inexistent_id(client: TestClient, monkeypatch):
+    test_response = {"detail": "Synspec task not found."}
+
+    def mock_crud_get_task(id, page=1, per_page=20):
+        return None
+
+    monkeypatch.setattr(crud, "get_task", mock_crud_get_task)
+
+    response = client.get(f"/synspec/{_TEST_UUID}")
+    assert response.status_code == 404  # nosec
+    assert response.json() == test_response  # nosec
+
+
 def test_pagination_links(client: TestClient, monkeypatch):
     monkeypatch.setattr(crud, "get_task", _mock_crud_get_task)
 


### PR DESCRIPTION
When providing an inexistent ID on the backend for the GET verb on the `/synspec/` route, it would be returned a valid response. 

This PR implements a 404 response on these cases. 